### PR TITLE
Increase episode fetch limit from 256 to 1024

### DIFF
--- a/ommer/src/main/kotlin/ommer/client/Client.kt
+++ b/ommer/src/main/kotlin/ommer/client/Client.kt
@@ -77,7 +77,7 @@ private suspend fun fetchEpisodes(
     apiKey: String,
 ): List<Item> {
     val items = mutableListOf<Item>()
-    var currentUri = "${baseUri.appendPath(urn)}/episodes?limit=256"
+    var currentUri = "${baseUri.appendPath(urn)}/episodes?limit=1024"
     var page = 1
     
     try {


### PR DESCRIPTION
## Description
Increase batch size of feed parsing for fewer api round trips

## Version Bump
<!-- Choose one by changing [ ] to [x] -->
- [ ] major (breaking changes)
- [x] minor (new features)
- [ ] patch (bug fixes)